### PR TITLE
8-4 UnixドメインソケットとTCPのベンチマーク

### DIFF
--- a/sec8/8-4/server_test.go
+++ b/sec8/8-4/server_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func BenchmarkTCPServer(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		conn, err := net.Dial("tcp", TCPServerAddr)
+		if err != nil {
+			panic(err)
+		}
+		request, err := http.NewRequest("get", "http://"+TCPServerAddr, nil)
+		if err != nil {
+			panic(err)
+		}
+		request.Write(conn)
+		response, err := http.ReadResponse(bufio.NewReader(conn), request)
+		if err != nil {
+			panic(err)
+		}
+		_, err = httputil.DumpResponse(response, true)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkUDSStreamServer(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		conn, err := net.Dial("unix", filepath.Join(os.TempDir(), SocketFilename))
+		if err != nil {
+			panic(err)
+		}
+		// TCPServerAddr is just passed and not used.
+		request, err := http.NewRequest("get", "http://"+TCPServerAddr, nil)
+		if err != nil {
+			panic(err)
+		}
+		request.Write(conn)
+		reqsponse, err := http.ReadResponse(bufio.NewReader(conn), request)
+		if err != nil {
+			panic(err)
+		}
+		_, err = httputil.DumpResponse(reqsponse, true)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	// init
+	go UnixDomainSocketStreamServer()
+	go TCPServer()
+	time.Sleep(time.Second)
+	// run test
+	code := m.Run()
+	// exit
+	os.Exit(code)
+}

--- a/sec8/8-4/tcp_server.go
+++ b/sec8/8-4/tcp_server.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+)
+
+const TCPServerAddr = "localhost:18888"
+
+func TCPServer() {
+	listener, err := net.Listen("tcp", TCPServerAddr)
+	if err != nil {
+		panic(err)
+	}
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			panic(err)
+		}
+		go func() {
+			request, err := http.ReadRequest(bufio.NewReader(conn))
+			if err != nil {
+				panic(err)
+			}
+			_, err = httputil.DumpRequest(request, true)
+			if err != nil {
+				panic(err)
+			}
+			response := http.Response{
+				StatusCode: 200,
+				ProtoMajor: 1,
+				ProtoMinor: 0,
+				Body:       io.NopCloser(strings.NewReader("Hello World\n")),
+			}
+			response.Write(conn)
+			conn.Close()
+		}()
+	}
+}

--- a/sec8/8-4/uds_stream_server.go
+++ b/sec8/8-4/uds_stream_server.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const SocketFilename = "bench-unixdomainsocket-stream"
+
+func UnixDomainSocketStreamServer() {
+	path := filepath.Join(os.TempDir(), SocketFilename)
+	os.Remove(path)
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		panic(err)
+	}
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			panic(err)
+		}
+		go func() {
+			request, err := http.ReadRequest(bufio.NewReader(conn))
+			if err != nil {
+				panic(err)
+			}
+			_, err = httputil.DumpRequest(request, true)
+			if err != nil {
+				panic(err)
+			}
+			response := http.Response{
+				StatusCode: 200,
+				ProtoMajor: 1,
+				ProtoMinor: 0,
+				Body:       io.NopCloser(strings.NewReader("Hello World\n")),
+			}
+			response.Write(conn)
+			conn.Close()
+		}()
+	}
+}


### PR DESCRIPTION
テキストの結果と比べるとUDSの速度が出てないっぽい。

```
❯ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: go-sys-study/sec8/8-4
cpu: Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
BenchmarkTCPServer-4                1670            628275 ns/op           52930 B/op        119 allocs/op
BenchmarkUDSStreamServer-4          9255            125086 ns/op           51519 B/op         79 allocs/op
PASS
ok      go-sys-study/sec8/8-4   4.118s

```