### PR TITLE
lint check時のgo versionを1.20系にする

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dominikh/staticcheck-action@v1.2.0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.20'
+    - uses: dominikh/staticcheck-action@v1.3.0
       with:
         version: "2022.1.1"


### PR DESCRIPTION
前コケてたのをgo versionを上げて再実行してみる

https://github.com/kumashun8/go-sys-study/actions/runs/4216802889/jobs/7320123763